### PR TITLE
Debug black screen video playback issue

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -73,7 +73,8 @@ compose.desktop {
                 obfuscate.set(false)
             }
 
-            modules("java.sql", "java.naming")
+            // Include required modules for vlcj (AWT/Swing, instrumentation, and unsupported)
+            modules("java.sql", "java.naming", "java.instrument", "jdk.unsupported")
         }
     }
 }


### PR DESCRIPTION
Use callback rendering for video on Linux/macOS and add VLC diagnostics to fix black screen in packaged builds.

The black screen issue (sound but no video) was observed only in packaged builds, not during testing. Switching to `CallbackMediaPlayerComponent` is a common solution for such problems with `vlcj` in packaged desktop applications. The added `java.instrument` and `jdk.unsupported` modules are necessary for the build process to succeed with these changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-f9a96083-18e2-49b8-9fb5-ff588e988d4a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f9a96083-18e2-49b8-9fb5-ff588e988d4a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

